### PR TITLE
Support running build script and compilation on different machines

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
-use std::path::Path;
+use std::path::{self, Path};
 
 use std::collections::BTreeMap;
 
@@ -19,12 +19,14 @@ mod mime_types;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
-    let dest_path = Path::new(&out_dir).join("mime_types_generated.rs");
+    let mime_types_generated_filename = "mime_types_generated.rs";
+    let dest_path = Path::new(&out_dir).join(mime_types_generated_filename);
     let mut outfile = BufWriter::new(File::create(&dest_path).unwrap());
 
     println!(
-        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={}",
-        dest_path.display()
+        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={separator}{filename}",
+        separator = path::MAIN_SEPARATOR,
+        filename = mime_types_generated_filename,
     );
 
     #[cfg(feature = "phf")]

--- a/src/impl_bin_search.rs
+++ b/src/impl_bin_search.rs
@@ -1,7 +1,7 @@
 use unicase::UniCase;
 
 include!("mime_types.rs");
-include!(env!("MIME_TYPES_GENERATED_PATH"));
+include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
 
 #[cfg(feature = "rev-map")]
 #[derive(Copy, Clone)]

--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -2,7 +2,7 @@ extern crate phf;
 
 use unicase::UniCase;
 
-include!(env!("MIME_TYPES_GENERATED_PATH"));
+include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
 
 #[cfg(feature = "rev-map")]
 struct TopLevelExts {


### PR DESCRIPTION
### **User description**
Build systems that perform remote execution usually want to be able to run build scripts and library compilation as different actions, potentially on different machines. This is because the build script compilation and execution can take place as soon as the package's `build-dependencies` are ready, while library compilation can take place as soon as `dependencies` are ready, which may be substantially later. If `dependencies` are ready later, the machine that dealt with the build script may not be immediately available at that time, and library compilation will run on any other available remote machine.

The `mime_guess` change from https://github.com/abonander/mime_guess/pull/79 disrupted this by exposing an absolute path from the machine that did build script execution and then trying to resolve that path later on the machine that does the library compilation. The two actions likely occur in different working directories. For example it's typical for remote executors to use directories that include a digest of the action's inputs, particularly if actions are distributed using a content-addressable storage where they are already uniquely identified by such a digest.

Cargo's API for build scripts is that anything written into `env::var_os("OUT_DIR")` by the build script execution will be available inside `env!("OUT_DIR")` during library compilation. It is not part of the API that those are necessarily the same absolute path to OUT_DIR both times.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes build script and compilation compatibility across different machines

- Updates handling of generated file paths to be relative to `OUT_DIR`

- Modifies environment variable usage for generated file inclusion


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.rs</strong><dd><code>Refactor build script to output relative generated file path</code></dd></summary>
<hr>

build.rs

<li>Defines generated filename as a constant for reuse<br> <li> Changes environment variable to only store the filename, not the <br>absolute path<br> <li> Prints <code>MIME_TYPES_GENERATED_PATH</code> as a separator plus filename, not <br>full path


</details>


  </td>
  <td><a href="https://github.com/ttys3/mime_guess2/pull/3/files#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>impl_bin_search.rs</strong><dd><code>Use OUT_DIR and env var for generated file inclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/impl_bin_search.rs

<li>Changes <code>include!</code> macro to use both <code>OUT_DIR</code> and <br><code>MIME_TYPES_GENERATED_PATH</code><br> <li> Ensures generated file is included using a path relative to <code>OUT_DIR</code>


</details>


  </td>
  <td><a href="https://github.com/ttys3/mime_guess2/pull/3/files#diff-7fbda1763bc872bb4fb57dfe352ee5ac9f298ca53918cd2d49a09617e353b81d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>impl_phf.rs</strong><dd><code>Fix generated file inclusion for remote compilation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/impl_phf.rs

<li>Updates <code>include!</code> macro to concatenate <code>OUT_DIR</code> and <br><code>MIME_TYPES_GENERATED_PATH</code><br> <li> Ensures correct file inclusion regardless of machine or working <br>directory


</details>


  </td>
  <td><a href="https://github.com/ttys3/mime_guess2/pull/3/files#diff-a4d8b47ff9d9ddd20385e3472c461975e835be8d9188e584ccfe597fbfe05ff3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>