### PR TITLE
Add missing feature gate for reverse mappings in PHF implementation

### DIFF
--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -15,6 +15,7 @@ pub fn get_mime_types(ext: &str) -> Option<&'static [&'static str]> {
     map_lookup(&MIME_TYPES, ext).cloned()
 }
 
+#[cfg(feature = "rev-map")]
 pub fn get_extensions(toplevel: &str, sublevel: &str) -> Option<&'static [&'static str]> {
     if toplevel == "*" {
         return Some(EXTS);


### PR DESCRIPTION
### **User description**
Previously the library would not compile with PHF enabled and default features disabled due to missing constants in the PHF implementation of get_extensions. This adds the feature gate found in the binary search implementation.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing `rev-map` feature gate to PHF implementation

- Fix compilation error when PHF enabled with default features disabled

- Align PHF implementation with binary search implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PHF Implementation"] -- "add feature gate" --> B["get_extensions function"]
  B -- "matches" --> C["Binary Search Implementation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>impl_phf.rs</strong><dd><code>Add feature gate to get_extensions function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/impl_phf.rs

<ul><li>Add <code>#[cfg(feature = "rev-map")]</code> attribute to <code>get_extensions</code> function<br> <li> Ensures compilation compatibility when PHF is enabled without default <br>features</ul>


</details>


  </td>
  <td><a href="https://github.com/ttys3/mime_guess2/pull/4/files#diff-a4d8b47ff9d9ddd20385e3472c461975e835be8d9188e584ccfe597fbfe05ff3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

