### PR TITLE
Add `.zst` as `application/zstd`

### DIFF
--- a/src/mime_types.rs
+++ b/src/mime_types.rs
@@ -1502,4 +1502,5 @@ pub static MIME_TYPES: &[(&str, &[&str])] = &[
     ("zir", &["application/vnd.zul"]),
     ("zirz", &["application/vnd.zul"]),
     ("zmm", &["application/vnd.handheld-entertainment+xml"]),
+    ("zst", &["application/zstd"]),
 ];


### PR DESCRIPTION
The Zstantard compression format has been standardized to use the extension ".zst" and media type "application/zstd", as per [RFC 8478] (and [IANA]). More details about this format can be found on [Wikipedia].

For reference, the same change has also been raised against [`mime_guess`](https://crates.io/crates/mime_guess) - https://github.com/abonander/mime_guess/pull/105.

[RFC 8478]: https://www.rfc-editor.org/rfc/rfc8478
[IANA]: https://www.iana.org/assignments/media-types/application/zstd
[Wikipedia]: https://en.wikipedia.org/wiki/Zstd