### PR TITLE
Fix cross-compilation: use concat!(env!("OUT_DIR"), ...) for generated include

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
-use std::path::{self, Path};
+use std::path::Path;
 
 use std::collections::BTreeMap;
 
@@ -22,12 +22,6 @@ fn main() {
     let mime_types_generated_filename = "mime_types_generated.rs";
     let dest_path = Path::new(&out_dir).join(mime_types_generated_filename);
     let mut outfile = BufWriter::new(File::create(&dest_path).unwrap());
-
-    println!(
-        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={separator}{filename}",
-        separator = path::MAIN_SEPARATOR,
-        filename = mime_types_generated_filename,
-    );
 
     #[cfg(feature = "phf")]
     build_forward_map(&mut outfile);

--- a/src/impl_bin_search.rs
+++ b/src/impl_bin_search.rs
@@ -1,7 +1,7 @@
 use unicase::UniCase;
 
 include!("mime_types.rs");
-include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
+include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
 
 #[cfg(feature = "rev-map")]
 #[derive(Copy, Clone)]

--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -2,7 +2,7 @@ extern crate phf;
 
 use unicase::UniCase;
 
-include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
+include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
 
 #[cfg(feature = "rev-map")]
 struct TopLevelExts {


### PR DESCRIPTION
## Summary

Replace the `MIME_TYPES_GENERATED_PATH` environment variable with the standard `concat!(env!("OUT_DIR"), "/mime_types_generated.rs")` pattern for including build-script-generated files.

The current approach sets `MIME_TYPES_GENERATED_PATH` in the build script using `path::MAIN_SEPARATOR` to construct a path fragment like `\mime_types_generated.rs` or `/mime_types_generated.rs`. This is then consumed via `include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")))` in the source files.

This breaks in cross-compilation and distributed build environments where `path::MAIN_SEPARATOR` in the build script may not match the separator expected by the compiler (e.g., when the build script runs on Windows but compilation targets Linux, or vice versa).

The fix uses the standard `concat!(env!("OUT_DIR"), "/mime_types_generated.rs")` pattern, which is the conventional approach used by most crates and avoids the platform-dependent separator entirely. Forward slashes work on all platforms in Rust's `include!` macro.

## Changes

- **build.rs**: Remove the `MIME_TYPES_GENERATED_PATH` env var emission and the now-unused `path` import
- **src/impl_bin_search.rs**: Use `concat!(env!("OUT_DIR"), "/mime_types_generated.rs")` directly
- **src/impl_phf.rs**: Same change