### PR TITLE
fix: use forward slash in include paths for cross-compilation support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::BufWriter;
-use std::path::{self, Path};
+use std::path::Path;
 
 use std::collections::BTreeMap;
 
@@ -22,12 +22,6 @@ fn main() {
     let mime_types_generated_filename = "mime_types_generated.rs";
     let dest_path = Path::new(&out_dir).join(mime_types_generated_filename);
     let mut outfile = BufWriter::new(File::create(&dest_path).unwrap());
-
-    println!(
-        "cargo:rustc-env=MIME_TYPES_GENERATED_PATH={separator}{filename}",
-        separator = path::MAIN_SEPARATOR,
-        filename = mime_types_generated_filename,
-    );
 
     #[cfg(feature = "phf")]
     build_forward_map(&mut outfile);

--- a/src/impl_bin_search.rs
+++ b/src/impl_bin_search.rs
@@ -1,7 +1,7 @@
 use unicase::UniCase;
 
 include!("mime_types.rs");
-include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
+include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
 
 #[cfg(feature = "rev-map")]
 #[derive(Copy, Clone)]

--- a/src/impl_phf.rs
+++ b/src/impl_phf.rs
@@ -2,7 +2,7 @@ extern crate phf;
 
 use unicase::UniCase;
 
-include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")));
+include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"));
 
 #[cfg(feature = "rev-map")]
 struct TopLevelExts {


### PR DESCRIPTION
## Summary

Replace the `MIME_TYPES_GENERATED_PATH` environment variable with a direct `concat!(env!("OUT_DIR"), "/mime_types_generated.rs")`.

The previous approach used `path::MAIN_SEPARATOR` in `build.rs` to construct the env var value. Since `build.rs` runs on the host, `MAIN_SEPARATOR` reflects the host's path convention, not the target's. For example, when cross-compiling on a Windows host for a Linux target, the env var would contain a backslash (e.g. `\mime_types_generated.rs`), producing an invalid path when concatenated with `OUT_DIR` on the target. Using a literal forward slash avoids this, as forward slashes are accepted in `include!` paths on all platforms.

## Changes

- **`build.rs`**: Remove the `cargo:rustc-env=MIME_TYPES_GENERATED_PATH` println and the now-unused `path` import
- **`src/impl_bin_search.rs`**: Replace `include!(concat!(env!("OUT_DIR"), env!("MIME_TYPES_GENERATED_PATH")))` with `include!(concat!(env!("OUT_DIR"), "/mime_types_generated.rs"))`
- **`src/impl_phf.rs`**: Same replacement

## Test plan

- `cargo build` passes
- `cargo test` passes (all 7 unit tests)